### PR TITLE
Add React autosuggest components

### DIFF
--- a/docs/data.json
+++ b/docs/data.json
@@ -2,21 +2,28 @@
   {"type":"frontend_framework","user":"reactjs","repo":"redux"},
   {"type":"frontend_framework","user":"facebook","repo":"react"},
   {"type":"frontend_framework","user":"angular","repo":"angular","package":"angular2"},
-  
+
   {"type":"bundler","user":"gulpjs","repo":"gulp"},
   {"type":"bundler","user":"gruntjs","repo":"grunt"},
   {"type":"bundler","user":"substack","repo":"node-browserify","package":"browserify"},
   {"type":"bundler","user":"webpack","repo":"webpack"},
-  
+
   {"type":"styles","user":"less","repo":"less.js","package":"less"},
   {"type":"styles","user":"sass","repo":"node-sass"},
   {"type":"styles","user":"postcss","repo":"postcss"},
-  
+
   {"type":"language","user":"Microsoft","repo":"TypeScript","package":"typescript"},
   {"type":"language","user":"jashkenas","repo":"coffeescript","package":"coffee-script"},
-  
+
   {"type":"testing_framework","user":"mochajs","repo":"mocha"},
   {"type":"testing_framework","user":"substack","repo":"tape"},
   {"type":"testing_framework","user":"jasmine","repo":"jasmine"},
-  {"type":"testing_framework","user":"facebook","repo":"jest","package":"jest-cli"}
+  {"type":"testing_framework","user":"facebook","repo":"jest","package":"jest-cli"},
+
+  {"type":"react_components","user":"moroshko","repo":"react-autosuggest"},
+  {"type":"react_components","user":"JedWatson","repo":"react-select"},
+  {"type":"react_components","user":"reactjs","repo":"react-autocomplete"},
+  {"type":"react_components","user":"ezequiel","repo":"react-typeahead-component"},
+  {"type":"react_components","user":"fmoo","repo":"react-typeahead"},
+  {"type":"react_components","user":"reactjs","repo":"react-modal"}
 ]

--- a/src/components/LinksList/index.js
+++ b/src/components/LinksList/index.js
@@ -27,6 +27,13 @@ class LinksList extends Component {
       'webpack/webpack'
     ].join(keysSeparator);
 
+    const reactAutosuggestComponents = [
+      'moroshko/react-autosuggest',
+      'reactjs/react-autocomplete',
+      'ezequiel/react-typeahead-component',
+      'fmoo/react-typeahead'
+    ].join(keysSeparator);
+
     return (
       <div className="LinksList">
         <h3 className="LinksList-title">Popular comparisons:</h3>
@@ -50,6 +57,13 @@ class LinksList extends Component {
               to={{ pathname: '/compare', query: { keys: reactD3Components } }}
               className="LinksList-list-link">
               React Components for D3
+            </Link>
+          </div>
+          <div className="LinksList-list-item">
+            <Link
+              to={{ pathname: '/compare', query: { keys: reactAutosuggestComponents } }}
+              className="LinksList-list-link">
+              React Autosuggest Components
             </Link>
           </div>
         </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ const names = {
   language: 'Languages',
   testing_framework: 'Testing frameworks',
   data_visualization: 'Data visualization',
+  react_components: 'React components',
   other: 'Other',
 };
 
@@ -17,6 +18,7 @@ const colors = {
   language: '#66a61e',
   testing_framework: '#e6ab02',
   data_visualization: '#a6761d',
+  react_components: '#0c7eaf',
   other: '#666666'
 };
 


### PR DESCRIPTION
First of all, thanks for a great project!

I tried to follow the README to add a comparison for React autosuggest components, but the API call doesn't seem to take into consideration the updated `data.json`. 

I'm expecting to see "React autosuggest components" under "Categories:", but no luck.

What am I missing?
